### PR TITLE
mach: Update `mach-core` dependency to `mach`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,8 @@
 # Cheers!
 # -andrewrk
 
+.zig-cache/
+.zig-out/
 zig-cache/
 zig-out/
 /release/

--- a/build.zig
+++ b/build.zig
@@ -15,7 +15,7 @@ pub fn build(b: *std.Build) !void {
     });
 
     const module = b.addModule("zig-imgui", .{
-        .root_source_file = .{ .path = "src/imgui.zig" },
+        .root_source_file = b.path("src/imgui.zig"),
         .imports = &.{
             .{ .name = "mach", .module = mach_dep.module("mach") },
         },
@@ -38,11 +38,11 @@ pub fn build(b: *std.Build) !void {
 
     try files.appendSlice(&.{
         "src/cimgui.cpp",
-        imgui_dep.path("imgui.cpp").getPath(b),
-        imgui_dep.path("imgui_widgets.cpp").getPath(b),
-        imgui_dep.path("imgui_tables.cpp").getPath(b),
-        imgui_dep.path("imgui_draw.cpp").getPath(b),
-        imgui_dep.path("imgui_demo.cpp").getPath(b),
+        imgui_dep.builder.path("imgui.cpp").getPath(b),
+        imgui_dep.builder.path("imgui_widgets.cpp").getPath(b),
+        imgui_dep.builder.path("imgui_tables.cpp").getPath(b),
+        imgui_dep.builder.path("imgui_draw.cpp").getPath(b),
+        imgui_dep.builder.path("imgui_demo.cpp").getPath(b),
     });
 
     if (use_freetype) {
@@ -58,7 +58,7 @@ pub fn build(b: *std.Build) !void {
     lib.addIncludePath(imgui_dep.path("."));
 
     for (files.items) |file| {
-        lib.addCSourceFile(.{ .file = .{ .path = file }, .flags = flags.items });
+        lib.addCSourceFile(.{ .file = .{ .cwd_relative = file }, .flags = flags.items });
     }
 
     b.installArtifact(lib);
@@ -84,7 +84,7 @@ pub fn build(b: *std.Build) !void {
     // Generator
     const generator_exe = b.addExecutable(.{
         .name = "mach-imgui-generator",
-        .root_source_file = .{ .path = "src/generate.zig" },
+        .root_source_file = b.path("src/generate.zig"),
         .target = target,
         .optimize = optimize,
     });

--- a/build.zig
+++ b/build.zig
@@ -57,8 +57,12 @@ pub fn build(b: *std.Build) !void {
 
     lib.addIncludePath(imgui_dep.path("."));
 
-    for (files.items) |file| {
-        lib.addCSourceFile(.{ .file = .{ .cwd_relative = file }, .flags = flags.items });
+    for (files.items, 0..) |file, i| {
+        if (i == 0) {
+            lib.addCSourceFile(.{ .file = b.path(file), .flags = flags.items });
+        } else {
+            lib.addCSourceFile(.{ .file = .{ .cwd_relative = file }, .flags = flags.items });
+        }
     }
 
     b.installArtifact(lib);

--- a/build.zig
+++ b/build.zig
@@ -56,10 +56,11 @@ pub fn build(b: *std.Build) !void {
     }
 
     lib.addIncludePath(imgui_dep.path("."));
-    lib.addCSourceFiles(.{
-        .files = files.items,
-        .flags = flags.items,
-    });
+
+    for (files.items) |file| {
+        lib.addCSourceFile(.{ .file = .{ .path = file }, .flags = flags.items });
+    }
+
     b.installArtifact(lib);
 
     // Example

--- a/build.zig
+++ b/build.zig
@@ -1,7 +1,7 @@
 const std = @import("std");
 const builtin = @import("builtin");
 
-const mach_core = @import("mach_core");
+const mach = @import("mach");
 
 pub fn build(b: *std.Build) !void {
     const target = b.standardTargetOptions(.{});
@@ -9,7 +9,7 @@ pub fn build(b: *std.Build) !void {
 
     const use_freetype = b.option(bool, "use_freetype", "Use Freetype") orelse false;
 
-    const mach_core_dep = b.dependency("mach_core", .{
+    const mach_dep = b.dependency("mach", .{
         .target = target,
         .optimize = optimize,
     });
@@ -17,7 +17,7 @@ pub fn build(b: *std.Build) !void {
     const module = b.addModule("zig-imgui", .{
         .root_source_file = .{ .path = "src/imgui.zig" },
         .imports = &.{
-            .{ .name = "mach-core", .module = mach_core_dep.module("mach-core") },
+            .{ .name = "mach", .module = mach_dep.module("mach") },
         },
     });
 
@@ -65,7 +65,7 @@ pub fn build(b: *std.Build) !void {
     // Example
     const build_options = b.addOptions();
 
-    const app = try mach_core.App.init(b, mach_core_dep.builder, .{
+    const app = try mach.CoreApp.init(b, mach_dep.builder, .{
         .name = "mach-imgui-example",
         .src = "examples/example_mach.zig",
         .target = target,

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -8,12 +8,13 @@
     .version = "0.1.0",
     .dependencies = .{
         .mach = .{
-            .url = "https://pkg.machengine.org/mach/279290bbf2f1adab0af00323280a07d6bfff47a5.tar.gz",
-            .hash = "1220ba5472217ef81455b19d540967049bbfaf768b30d04534865707e907ee1c4aec",
+            .url = "https://pkg.machengine.org/mach/b72f0e11b6d292c2b60789359a61f7ee6d7dc371.tar.gz",
+            .hash = "122015e1dac4afaf275f7f2adde3814e6a27f5799cbef96bb487ee305f7e33f4dca3",
         },
-        .freetype = .{
-            .url = "https://pkg.machengine.org/freetype/398638fd1cb723e478658ea371fe3be1a4dce0ae.tar.gz",
-            .hash = "12208c57b72e3fb5c8d5d3e667e2e21ca1d9e2b6fc3f84182b320f63933f591823da",
+        .mach_freetype = .{
+            .url = "https://pkg.machengine.org/mach-freetype/86fc8024d4ddd53df75dfa4f3ad4eebe0b1b4284.tar.gz",
+            .hash = "12206251ed342f400b80abf3c338521f5d8c83eb596899abf77a2afe0cfd46e61ff0",
+            .lazy = true,
         },
         .imgui = .{
             .url = "https://github.com/ocornut/imgui/archive/refs/tags/v1.90.tar.gz",

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -7,9 +7,9 @@
     .name = "mach-imgui",
     .version = "0.1.0",
     .dependencies = .{
-        .mach_core = .{
-            .url = "https://pkg.machengine.org/mach-core/2422c164842eadebd937509c591e3d36aa92470b.tar.gz",
-            .hash = "122038cccd01128c92f12cfeee34677bf64f423d9aebb17f0648ef4d4a58e452ab71",
+        .mach = .{
+            .url = "https://pkg.machengine.org/mach/ea6a9438aa13ee83f9239d3aada352dcb9ea8b7c.tar.gz",
+            .hash = "1220a1ac8dba2fee590af6bafce6e1d5a768b93456e8877fe3d5402f19aec3d5d696",
         },
         .freetype = .{
             .url = "https://pkg.machengine.org/freetype/398638fd1cb723e478658ea371fe3be1a4dce0ae.tar.gz",

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -8,8 +8,8 @@
     .version = "0.1.0",
     .dependencies = .{
         .mach = .{
-            .url = "https://pkg.machengine.org/mach/ea6a9438aa13ee83f9239d3aada352dcb9ea8b7c.tar.gz",
-            .hash = "1220a1ac8dba2fee590af6bafce6e1d5a768b93456e8877fe3d5402f19aec3d5d696",
+            .url = "https://pkg.machengine.org/mach/279290bbf2f1adab0af00323280a07d6bfff47a5.tar.gz",
+            .hash = "1220ba5472217ef81455b19d540967049bbfaf768b30d04534865707e907ee1c4aec",
         },
         .freetype = .{
             .url = "https://pkg.machengine.org/freetype/398638fd1cb723e478658ea371fe3be1a4dce0ae.tar.gz",

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -8,8 +8,8 @@
     .version = "0.1.0",
     .dependencies = .{
         .mach_core = .{
-            .url = "https://pkg.machengine.org/mach-core/370bc1504cebaffcda5ed1ae9915fd2ac6778479.tar.gz",
-            .hash = "12205da1ecba58ba8c9ca65dbf75e32f42fde0490d34a98596ae72d4d3db81659dc5",
+            .url = "https://pkg.machengine.org/mach-core/2422c164842eadebd937509c591e3d36aa92470b.tar.gz",
+            .hash = "122038cccd01128c92f12cfeee34677bf64f423d9aebb17f0648ef4d4a58e452ab71",
         },
         .freetype = .{
             .url = "https://pkg.machengine.org/freetype/398638fd1cb723e478658ea371fe3be1a4dce0ae.tar.gz",

--- a/examples/example_mach.zig
+++ b/examples/example_mach.zig
@@ -2,8 +2,9 @@ const std = @import("std");
 const build_options = @import("build-options");
 const imgui = @import("imgui");
 const imgui_mach = imgui.backends.mach;
-const core = @import("mach").core;
-const gpu = core.gpu;
+const mach = @import("mach");
+const core = mach.core;
+const gpu = mach.gpu;
 
 pub const App = @This();
 

--- a/examples/example_mach.zig
+++ b/examples/example_mach.zig
@@ -2,7 +2,7 @@ const std = @import("std");
 const build_options = @import("build-options");
 const imgui = @import("imgui");
 const imgui_mach = imgui.backends.mach;
-const core = @import("mach-core");
+const core = @import("mach").core;
 const gpu = core.gpu;
 
 pub const App = @This();

--- a/src/imgui_mach.zig
+++ b/src/imgui_mach.zig
@@ -1,6 +1,6 @@
 const std = @import("std");
 const imgui = @import("imgui.zig");
-const core = @import("mach-core");
+const core = @import("mach").core;
 const gpu = core.gpu;
 
 var allocator: std.mem.Allocator = undefined;


### PR DESCRIPTION
This just updates the dependency for mach core to the main mach repo as core is now part of mach proper. 